### PR TITLE
Add CalculateCalendarLogic to dependency

### DIFF
--- a/CalendarKit.podspec
+++ b/CalendarKit.podspec
@@ -12,4 +12,5 @@ Pod::Spec.new do |s|
   s.source_files = 'Source/**/*'
   s.dependency 'DateToolsSwift'
   s.dependency 'Neon'
+  s.dependency 'CalculateCalendarLogic'
 end


### PR DESCRIPTION
# PRが解決する内容
- CalendarKitの依存関係にCalculateCalendarLogicを追加

# 動作確認項目
- [x] App側からCalendarKitの取得先をfeature/add_calculate_calendar にした上でpod installし、CalendarKitないからCalculateCalendarLogicが呼び出されることを確認

# TODO
- App側のpod install(Podfileの修正は不要)